### PR TITLE
Point rel XML files to appropriate indices

### DIFF
--- a/lib/powerpoint/slide/intro.rb
+++ b/lib/powerpoint/slide/intro.rb
@@ -5,7 +5,7 @@ module Powerpoint
   module Slide
     class Intro
       include Powerpoint::Util
-      
+
       attr_reader :title, :subtitile
 
       def initialize(options={})
@@ -23,7 +23,7 @@ module Powerpoint
       end
 
       def save_rel_xml(extract_path, index)
-        render_view('textual_rel.xml.erb', "#{extract_path}/ppt/slides/_rels/slide#{index}.xml.rels")
+        render_view('textual_rel.xml.erb', "#{extract_path}/ppt/slides/_rels/slide#{index}.xml.rels", index: index)
       end
       private :save_rel_xml
 

--- a/lib/powerpoint/slide/pictorial.rb
+++ b/lib/powerpoint/slide/pictorial.rb
@@ -41,7 +41,7 @@ module Powerpoint
       private :default_coords
 
       def save_rel_xml(extract_path, index)
-        render_view('pictorial_rel.xml.erb', "#{extract_path}/ppt/slides/_rels/slide#{index}.xml.rels")
+        render_view('pictorial_rel.xml.erb', "#{extract_path}/ppt/slides/_rels/slide#{index}.xml.rels", index: index)
       end
       private :save_rel_xml
 

--- a/lib/powerpoint/slide/picture_description.rb
+++ b/lib/powerpoint/slide/picture_description.rb
@@ -50,7 +50,7 @@ module Powerpoint
       private :default_coords
 
       def save_rel_xml(extract_path, index)
-        render_view('picture_description_rels.xml.erb', "#{extract_path}/ppt/slides/_rels/slide#{index}.xml.rels")
+        render_view('picture_description_rels.xml.erb', "#{extract_path}/ppt/slides/_rels/slide#{index}.xml.rels", index: index)
       end
       private :save_rel_xml
 

--- a/lib/powerpoint/slide/text_picture_split.rb
+++ b/lib/powerpoint/slide/text_picture_split.rb
@@ -41,7 +41,7 @@ module Powerpoint
       private :default_coords
 
       def save_rel_xml(extract_path, index)
-        render_view('text_picture_split_rel.xml.erb', "#{extract_path}/ppt/slides/_rels/slide#{index}.xml.rels")
+        render_view('text_picture_split_rel.xml.erb', "#{extract_path}/ppt/slides/_rels/slide#{index}.xml.rels", index: index)
       end
       private :save_rel_xml
 

--- a/lib/powerpoint/slide/textual.rb
+++ b/lib/powerpoint/slide/textual.rb
@@ -5,7 +5,7 @@ module Powerpoint
   module Slide
     class Textual
       include Powerpoint::Util
-      
+
       attr_reader :title, :content
 
       def initialize(options={})
@@ -19,7 +19,7 @@ module Powerpoint
       end
 
       def save_rel_xml(extract_path, index)
-        render_view('textual_rel.xml.erb', "#{extract_path}/ppt/slides/_rels/slide#{index}.xml.rels")
+        render_view('textual_rel.xml.erb', "#{extract_path}/ppt/slides/_rels/slide#{index}.xml.rels", index: index)
       end
       private :save_rel_xml
 

--- a/lib/powerpoint/util.rb
+++ b/lib/powerpoint/util.rb
@@ -5,10 +5,11 @@ module Powerpoint
       px * 12700
     end
 
-    def render_view(template_name, path)
+    def render_view(template_name, path, variables = {})
       view_contents = read_template(template_name)
       renderer = ERB.new(view_contents)
-      data = renderer.result(binding)
+      b = merge_variables(binding, variables)
+      data = renderer.result(b)
 
       File.open(path, 'w') { |f| f << data }
     end
@@ -25,6 +26,14 @@ module Powerpoint
       image_name = File.basename(image_path)
       dest_path = "#{extract_path}/ppt/media/#{image_name}"
       FileUtils.copy_file(image_path, dest_path) unless File.exist?(dest_path)
+    end
+
+    def merge_variables(b, variables)
+      return b if variables.empty?
+      variables.each do |k,v|
+        b.local_variable_set(k, v)
+      end
+      b
     end
   end
 end

--- a/lib/powerpoint/views/pictorial_rel.xml.erb
+++ b/lib/powerpoint/views/pictorial_rel.xml.erb
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-  <Relationship Id="rId1" Target="../slideLayouts/slideLayout2.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout"/>
+  <Relationship Id="rId1" Target="../slideLayouts/slideLayout<%= index %>.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout"/>
   <Relationship Id="rId2" Target="../media/<%= image_name %>" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
 </Relationships>

--- a/lib/powerpoint/views/picture_description_rels.xml.erb
+++ b/lib/powerpoint/views/picture_description_rels.xml.erb
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-  <Relationship Id="rId1" Target="../slideLayouts/slideLayout9.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout"/>
+  <Relationship Id="rId1" Target="../slideLayouts/slideLayout<%= index %>.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout"/>
   <Relationship Id="rId2" Target="../media/<%= image_name %>" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"/>
 </Relationships>

--- a/lib/powerpoint/views/text_picture_split_rel.xml.erb
+++ b/lib/powerpoint/views/text_picture_split_rel.xml.erb
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout4.xml" />
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout<%= index %>.xml" />
   <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/<%= image_name %>" />
 </Relationships>

--- a/lib/powerpoint/views/textual_rel.xml.erb
+++ b/lib/powerpoint/views/textual_rel.xml.erb
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-  <Relationship Id="rId1" Target="../slideLayouts/slideLayout1.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout"/>
+  <Relationship Id="rId1" Target="../slideLayouts/slideLayout<%= index %>.xml" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout"/>
 </Relationships>


### PR DESCRIPTION
Fixes formatting for textual slides on Office 2010 for Mac OSX 10.11.6. 

#### Before
![before screenshot](https://cl.ly/1g233u2s041P/Screen%20Shot%202017-04-01%20at%203.42.05%20PM.png)

#### After
![after screenshot](https://cl.ly/0m2R1h3s3x3o/Screen%20Shot%202017-04-01%20at%203.42.30%20PM.png)

